### PR TITLE
Make main the default branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,17 +2,17 @@ name: npm-publish
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   npm-publish:
     name: npm-publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: Set up Node.js
-        uses: actions/setup-node@master
+        uses: actions/setup-node@main
         with:
           node-version: 12.18.3
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS Lambda Plugin
 
-![preview of Lambda Widget](https://raw.githubusercontent.com/RoadieHQ/backstage-plugin-aws-lambda/master/docs/lambda-widget.png)
+![preview of Lambda Widget](https://raw.githubusercontent.com/RoadieHQ/backstage-plugin-aws-lambda/main/docs/lambda-widget.png)
 
 ## Plugin Setup
 


### PR DESCRIPTION
GitHub is making `main` the default branch name for repos. I wanted to check what work might be involved in moving all repos to `main`.

Apart from changing the branch name, it's good to check for:

1. GitHub actions workflows which checkout the `master` branch or are triggered when pull requests to the `master` branch occur.
2. Screenshots which point to a file URL which references the master branch. Screenshots can be in the README of the project but they can also be on roadie.io/backstage/plugins or on other websites.