### PR TITLE
change oss tag to lower case

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,7 +8,7 @@ metadata:
     github.com/project-slug: roadiehq/backstage-plugin-aws-lambda
   tags:
     - plugin
-    - OSS
+    - oss
   links:
     - url: https://www.npmjs.com/package/@roadiehq/backstage-plugin-aws-lambda
       title: NPM


### PR DESCRIPTION
It was failing with the error: expected a string that is sequences of [a-z0-9]